### PR TITLE
feat: dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,9 @@ updates:
   - package-ecosystem: "pip"
     directory: "/docker"
     schedule:
-      interval: "daily"
+      interval: "monthly"
   - package-ecosystem: "pip"
     directory: "/requirements"
     schedule:
-      interval: "daily"
+      interval: "monthly"
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/docker"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "/requirements"
+    schedule:
+      interval: "daily"
+

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -1,0 +1,11 @@
+gevent>=1.1b4; python_version >= '3'
+httpx
+pip
+passlib>=1.6
+pytest>=6.2.2
+pytest-cov
+setuptools>=40.0,<62.0.0
+tox
+twine
+webtest
+wheel>=0.25.0

--- a/requirements/test.pip
+++ b/requirements/test.pip
@@ -1,14 +1,3 @@
 # Just the absolutely necessary extra requirements for
 # running tests
-
-gevent>=1.1b4; python_version >= '3'
-httpx
-pip
-passlib>=1.6
-pytest>=6.2.2
-pytest-cov
-setuptools>=40.0,<62.0.0
-tox
-twine
-webtest
-wheel>=0.25.0
+-r test-requirements.txt


### PR DESCRIPTION
- add dependabot yml file to look in the docker & requirements folders
- split the requirements out of the test.pip into a test-requirements.pip file so dependabot recognizes it

It was found that in order to have the python dependabot recognize the requirements a naming convention had to be followed